### PR TITLE
Fix(#106): fix missing JSON key-value and writing in Questionario

### DIFF
--- a/Elmer/Daniel_JSON_Files_Elmer/json/finish_info.json
+++ b/Elmer/Daniel_JSON_Files_Elmer/json/finish_info.json
@@ -1,5 +1,6 @@
 {
-    "title_text": "Questionario finalizado, estas listo para aprender?",
+    "window_title": "Cuestionario Hexad-12",
+    "title_text": "Cuestionario finalizado, estas listo para aprender?",
     "title_font_size": 20,
     "title_margin": 10,
     "title_word_wrap": true,


### PR DESCRIPTION
- Fix writing in the word Questionario in finish_window
- Add missing JSON key-value `window_title` in finish_info.json